### PR TITLE
header and footer comments

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,6 +1,12 @@
 <?php
 
 /**
+ * Third party plugins that hijack the theme will call wp_footer() to get the footer template.
+ * We use this to end our output buffer (started in header.php) and render into the view/page-plugin.twig template.
+ *
+ * If you're not using a plugin that requries this behavior (ones that do include Events Calendar Pro and
+ * WooCommerce) you can delete this file and header.php
+ *
  * @package WordPress
  * @subpackage Jackpine
  * @since Jackpine 0.1.0

--- a/header.php
+++ b/header.php
@@ -1,6 +1,12 @@
 <?php
 
 /**
+ * Third party plugins that hijack the theme will call wp_head() to get the header template.
+ * We use this to start our output buffer and render into the view/page-plugin.twig template in footer.php
+ *
+ * If you're not using a plugin that requries this behavior (ones that do include Events Calendar Pro and
+ * WooCommerce) you can delete this file and footer.php
+ *
  * @package WordPress
  * @subpackage Jackpine
  * @since Jackpine 0.1.0


### PR DESCRIPTION
Add comments to clarify the purpose of the `ob_start()`, `ob_get_clean()` statements, and the need for header.php and footer.php templates in the first place. These comments are taken directly from timber/starter-theme.